### PR TITLE
Add option for vector origin

### DIFF
--- a/source/glwidget.cpp
+++ b/source/glwidget.cpp
@@ -288,16 +288,18 @@ void GLWidget::setBackgroundColor(QColor color) {
     needsUpdate = true;
 }
 
-void GLWidget::setSpriteDimensions(int newslices, float length, float radius, float tipLengthRatio, float shaftRadiusRatio)
+void GLWidget::setSpriteDimensions(int newslices, float length, float radius, float tipLengthRatio, float shaftRadiusRatio, QString origin)
 {
     if ( (slices != newslices) || (vectorLength != length) || (vectorRadius != radius) ||
-         (vectorTipLengthRatio != tipLengthRatio) || (vectorShaftRadiusRatio != shaftRadiusRatio) )
+         (vectorTipLengthRatio != tipLengthRatio) || (vectorShaftRadiusRatio != shaftRadiusRatio) ||
+         (vectorOrigin != origin) )
     {
         slices = newslices;
         vectorLength = length;
         vectorRadius = radius;
         vectorTipLengthRatio = tipLengthRatio;
         vectorShaftRadiusRatio = shaftRadiusRatio;
+        vectorOrigin = origin;
         initializeVect(slices, 5.0f*vectorLength, 1.0f*vectorRadius, vectorTipLengthRatio, vectorShaftRadiusRatio);
         initializeCone(slices, 1.0*vectorRadius, 2.0*vectorLength);
         needsUpdate = true;

--- a/source/glwidget.h
+++ b/source/glwidget.h
@@ -35,7 +35,7 @@ public:
     // View Preferences
     virtual void toggleDisplay(int type);
     virtual void setBackgroundColor(QColor color);
-    virtual void setSpriteDimensions(int newslices, float length, float radius, float tipLengthRatio, float shaftRadiusRatio);
+    virtual void setSpriteDimensions(int newslices, float length, float radius, float tipLengthRatio, float shaftRadiusRatio, QString origin);
     virtual void setBrightness(float bright);
     void setColorScale(QString value);
     void setColoredQuantity(QString value);
@@ -132,6 +132,7 @@ private:
     int zSliceLow, zSliceHigh;
     QString colorScale;
     QString coloredQuantity;
+    QString vectorOrigin;
 
     // Mouse control
     QVector2D previousMousePosition;

--- a/source/glwidget_assets.cpp
+++ b/source/glwidget_assets.cpp
@@ -251,7 +251,16 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
     vect.vao->bind();
 //    qDebug() << "Slices" << slices << "Height" << height << "Radius" << radius << "Tip Fraction" << fractionTip << "Inner Fraction" << fractionInner;
     float normScale = 1.0/sqrt(height*height + radius*radius);
-    float offset = height*(1.0f-fractionTip);
+    float headOffset, tailOffset;
+    if (vectorOrigin == "Tail") {
+        tailOffset = 0.0f;
+        headOffset = height;
+    } else { // Center origin
+        tailOffset = -height/2.0f;
+        headOffset =  height/2.0f;
+    }
+    float centerOffset = tailOffset + height*(1.0f-fractionTip);
+
     float tipHeight = height*fractionTip;
 
     std::vector<GLfloat> vertices;
@@ -260,7 +269,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( 0.0f);
         vertices.push_back( 0.0f);
-        vertices.push_back( height);
+        vertices.push_back( headOffset);
         // Normal
         vertices.push_back( normScale*tipHeight*cos(2.0*PI*(i+0.5)/slices));
         vertices.push_back(-normScale*tipHeight*sin(2.0*PI*(i+0.5)/slices));
@@ -268,7 +277,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*cos(2.0*PI*(i+1)/slices));
         vertices.push_back(-radius*sin(2.0*PI*(i+1)/slices));
-        vertices.push_back( offset);
+        vertices.push_back( centerOffset);
         // Normal
         vertices.push_back( normScale*tipHeight*cos(2.0*PI*(i+0.5)/slices));
         vertices.push_back(-normScale*tipHeight*sin(2.0*PI*(i+0.5)/slices));
@@ -276,7 +285,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*cos(2.0*PI*i/slices));
         vertices.push_back(-radius*sin(2.0*PI*i/slices));
-        vertices.push_back( offset);
+        vertices.push_back( centerOffset);
         // Normal
         vertices.push_back( normScale*tipHeight*cos(2.0*PI*(i+0.5)/slices));
         vertices.push_back(-normScale*tipHeight*sin(2.0*PI*(i+0.5)/slices));
@@ -287,7 +296,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
-        vertices.push_back(offset);
+        vertices.push_back(centerOffset);
         // Normal
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
@@ -295,7 +304,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*cos(2.0*PI*(i-1)/slices));
         vertices.push_back(-radius*sin(2.0*PI*(i-1)/slices));
-        vertices.push_back(offset);
+        vertices.push_back(centerOffset);
         // Normal
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
@@ -303,7 +312,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*cos(2.0*PI*(i)/slices));
         vertices.push_back(-radius*sin(2.0*PI*(i)/slices));
-        vertices.push_back(offset);
+        vertices.push_back(centerOffset);
         // Normal
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
@@ -314,7 +323,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
-        vertices.push_back(0.0);
+        vertices.push_back(tailOffset);
         // Normal
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
@@ -322,7 +331,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i-1)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i-1)/slices));
-        vertices.push_back(0.0);
+        vertices.push_back(tailOffset);
         // Normal
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
@@ -330,7 +339,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i)/slices));
-        vertices.push_back(0.0);
+        vertices.push_back(tailOffset);
         // Normal
         vertices.push_back(0.0f);
         vertices.push_back(0.0f);
@@ -341,7 +350,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i)/slices));
-        vertices.push_back(0.0);
+        vertices.push_back(tailOffset);
         // Normal
         vertices.push_back( cos(2.0*PI*(i-0.5)/slices));
         vertices.push_back(-sin(2.0*PI*(i-0.5)/slices));
@@ -349,7 +358,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i-1)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i-1)/slices));
-        vertices.push_back(0.0);
+        vertices.push_back(tailOffset);
         // Normal
         vertices.push_back( cos(2.0*PI*(i-0.5)/slices));
         vertices.push_back(-sin(2.0*PI*(i-0.5)/slices));
@@ -357,7 +366,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i)/slices));
-        vertices.push_back(offset);
+        vertices.push_back(centerOffset);
         // Normal
         vertices.push_back( cos(2.0*PI*(i-0.5)/slices));
         vertices.push_back(-sin(2.0*PI*(i-0.5)/slices));
@@ -367,7 +376,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i-1)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i-1)/slices));
-        vertices.push_back(0.0);
+        vertices.push_back(tailOffset);
         // Normal
         vertices.push_back( cos(2.0*PI*(i-0.5)/slices));
         vertices.push_back(-sin(2.0*PI*(i-0.5)/slices));
@@ -375,7 +384,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i-1)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i-1)/slices));
-        vertices.push_back(offset);
+        vertices.push_back(centerOffset);
         // Normal
         vertices.push_back( cos(2.0*PI*(i-0.5)/slices));
         vertices.push_back(-sin(2.0*PI*(i-0.5)/slices));
@@ -383,7 +392,7 @@ bool GLWidget::initializeVect(int slices, float height, float radius, float frac
         // Vertex
         vertices.push_back( radius*fractionInner*cos(2.0*PI*(i)/slices));
         vertices.push_back(-radius*fractionInner*sin(2.0*PI*(i)/slices));
-        vertices.push_back(offset);
+        vertices.push_back(centerOffset);
         // Normal
         vertices.push_back( cos(2.0*PI*(i-0.5)/slices));
         vertices.push_back(-sin(2.0*PI*(i-0.5)/slices));

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -86,3 +86,8 @@ QString Preferences::getColorQuantity()
 {
     return ui->coloredQuantityGroup->checkedButton()->text();
 }
+
+QString Preferences::getVectorOrigin()
+{
+    return ui->vectorOriginGroup->checkedButton()->text();
+}

--- a/source/preferences.h
+++ b/source/preferences.h
@@ -25,6 +25,7 @@ public:
     QSize getImageDimensions();
     QString getColorScale();
     QString getColorQuantity();
+    QString getVectorOrigin();
     ~Preferences();
 
 private:

--- a/source/preferences.ui
+++ b/source/preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>397</width>
-    <height>411</height>
+    <width>530</width>
+    <height>457</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -239,6 +239,42 @@
            <property name="lineWidth">
             <number>2</number>
            </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_14">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Vector Origin</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="vectorTail">
+           <property name="text">
+            <string>Tail</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">vectorOriginGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="vectorCenter">
+           <property name="text">
+            <string>Center</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">vectorOriginGroup</string>
+           </attribute>
           </widget>
          </item>
          <item>
@@ -934,5 +970,6 @@
  <buttongroups>
   <buttongroup name="colorScaleGroup"/>
   <buttongroup name="coloredQuantityGroup"/>
+  <buttongroup name="vectorOriginGroup"/>
  </buttongroups>
 </ui>

--- a/source/preferences.ui
+++ b/source/preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>530</width>
-    <height>457</height>
+    <width>603</width>
+    <height>466</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="Sprites">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="colorTab">
       <attribute name="title">
@@ -242,6 +242,357 @@
           </widget>
          </item>
          <item>
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>1</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="spritesTab">
+      <attribute name="title">
+       <string>Sprites</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Cone/Vector Resolution (slices)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="spriteResolution">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="minimum">
+              <number>4</number>
+             </property>
+             <property name="maximum">
+              <number>48</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>16</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSlider" name="spriteResolutionSlider">
+           <property name="minimum">
+            <number>4</number>
+           </property>
+           <property name="maximum">
+            <number>48</number>
+           </property>
+           <property name="value">
+            <number>16</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QLabel" name="label_12">
+             <property name="text">
+              <string>Cone/Vector Length (Relative to default)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="vectorLength">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>200</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSlider" name="vectorLengthSlider">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>200</number>
+           </property>
+           <property name="value">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Cone/Vector Radius (Relative to default)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="vectorRadius">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>200</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSlider" name="vectorRadiusSlider">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>200</number>
+           </property>
+           <property name="value">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QLabel" name="label_11">
+             <property name="text">
+              <string>Vector Tip Percentage of Length</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="tipPercent">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="minimum">
+              <number>10</number>
+             </property>
+             <property name="maximum">
+              <number>90</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>40</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSlider" name="tipPercentSlider">
+           <property name="minimum">
+            <number>10</number>
+           </property>
+           <property name="maximum">
+            <number>90</number>
+           </property>
+           <property name="value">
+            <number>40</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QLabel" name="label_13">
+             <property name="text">
+              <string>Vector Shaft Percentage of Radius</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_5">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="shaftRadiusPercent">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="minimum">
+              <number>20</number>
+             </property>
+             <property name="maximum">
+              <number>80</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>40</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSlider" name="shaftRadiusPercentSlider">
+           <property name="minimum">
+            <number>20</number>
+           </property>
+           <property name="maximum">
+            <number>80</number>
+           </property>
+           <property name="value">
+            <number>40</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>1</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
           <widget class="QLabel" name="label_14">
            <property name="font">
             <font>
@@ -278,349 +629,19 @@
           </widget>
          </item>
          <item>
-          <spacer name="verticalSpacer_2">
+          <spacer name="verticalSpacer_5">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
              <width>20</width>
-             <height>1</height>
+             <height>40</height>
             </size>
            </property>
           </spacer>
          </item>
         </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab">
-      <attribute name="title">
-       <string>Sprites</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Cone/Vector Resolution (slices)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="spriteResolution">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-           <property name="minimum">
-            <number>4</number>
-           </property>
-           <property name="maximum">
-            <number>48</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>16</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QSlider" name="spriteResolutionSlider">
-         <property name="minimum">
-          <number>4</number>
-         </property>
-         <property name="maximum">
-          <number>48</number>
-         </property>
-         <property name="value">
-          <number>16</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <item>
-          <widget class="QLabel" name="label_12">
-           <property name="text">
-            <string>Cone/Vector Length (Relative to default)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="vectorLength">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>200</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>100</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QSlider" name="vectorLengthSlider">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>200</number>
-         </property>
-         <property name="value">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLabel" name="label_10">
-           <property name="text">
-            <string>Cone/Vector Radius (Relative to default)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="vectorRadius">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>200</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>100</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QSlider" name="vectorRadiusSlider">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>200</number>
-         </property>
-         <property name="value">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="QLabel" name="label_11">
-           <property name="text">
-            <string>Vector Tip Percentage of Length</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="tipPercent">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-           <property name="minimum">
-            <number>10</number>
-           </property>
-           <property name="maximum">
-            <number>90</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>40</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QSlider" name="tipPercentSlider">
-         <property name="minimum">
-          <number>10</number>
-         </property>
-         <property name="maximum">
-          <number>90</number>
-         </property>
-         <property name="value">
-          <number>40</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <item>
-          <widget class="QLabel" name="label_13">
-           <property name="text">
-            <string>Vector Shaft Percentage of Radius</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="shaftRadiusPercent">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-           <property name="minimum">
-            <number>20</number>
-           </property>
-           <property name="maximum">
-            <number>80</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>40</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QSlider" name="shaftRadiusPercentSlider">
-         <property name="minimum">
-          <number>20</number>
-         </property>
-         <property name="maximum">
-          <number>80</number>
-         </property>
-         <property name="value">
-          <number>40</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>1</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>
@@ -968,8 +989,8 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="colorScaleGroup"/>
   <buttongroup name="coloredQuantityGroup"/>
+  <buttongroup name="colorScaleGroup"/>
   <buttongroup name="vectorOriginGroup"/>
  </buttongroups>
 </ui>

--- a/source/window.cpp
+++ b/source/window.cpp
@@ -252,7 +252,7 @@ void Window::keyPressEvent(QKeyEvent *e)
 void Window::updatePrefs() {
     viewport->setBackgroundColor(prefs->getBackgroundColor());
     viewport->setSpriteDimensions(prefs->getSpriteResolution(), prefs->getVectorLength(), prefs->getVectorRadius(),
-                                  prefs->getVectorTipToTail(), prefs->getVectorInnerToOuter());
+                                  prefs->getVectorTipToTail(), prefs->getVectorInnerToOuter(), prefs->getVectorOrigin());
     viewport->setBrightness(prefs->getBrightness());
     if (prefs->getImageDimensions() == QSize(-1,-1)) {
         viewport->setFixedSize(QWIDGETSIZE_MAX,QWIDGETSIZE_MAX);


### PR DESCRIPTION
This was a feature request.
Origin of each vector can be set to center of its cell, in addition to the default option tail.