### PR TITLE
Add option to scale sprite proportionally to the largest magnitude

### DIFF
--- a/source/glwidget.cpp
+++ b/source/glwidget.cpp
@@ -228,7 +228,8 @@ void GLWidget::paintGL()
                                         znodes > subsampling ? (float)subsampling : 1.0f);
                         } else {
                             // Rotate the cones or vectors, but don't mess with their aspect ratios...
-                            model.scale(1.0f + (float)subsampling*0.4f);
+                            float scale = (spriteScale == "Proportional") ? mag/maxmag : 1.0f;
+                            model.scale((1.0f + (float)subsampling*0.4f)*scale);
                             model.rotate(180.0*(phi+0.5*PI)/PI, 0.0, 0.0, 1.0);
                             model.rotate(180.0*theta/PI,        1.0, 0.0, 0.0);
                         }
@@ -320,4 +321,9 @@ void GLWidget::setColoredQuantity(QString value)
 void GLWidget::setColorScale(QString value)
 {
     colorScale = value;
+}
+
+void GLWidget::setSpriteScale(QString value)
+{
+    spriteScale = value;
 }

--- a/source/glwidget.h
+++ b/source/glwidget.h
@@ -38,6 +38,7 @@ public:
     virtual void setSpriteDimensions(int newslices, float length, float radius, float tipLengthRatio, float shaftRadiusRatio, QString origin);
     virtual void setBrightness(float bright);
     void setColorScale(QString value);
+    void setSpriteScale(QString value);
     void setColoredQuantity(QString value);
 
 public slots:
@@ -133,6 +134,7 @@ private:
     QString colorScale;
     QString coloredQuantity;
     QString vectorOrigin;
+    QString spriteScale;
 
     // Mouse control
     QVector2D previousMousePosition;

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -91,3 +91,8 @@ QString Preferences::getVectorOrigin()
 {
     return ui->vectorOriginGroup->checkedButton()->text();
 }
+
+QString Preferences::getSpriteScale()
+{
+    return ui->spriteScaleGroup->checkedButton()->text();
+}

--- a/source/preferences.h
+++ b/source/preferences.h
@@ -26,6 +26,7 @@ public:
     QString getColorScale();
     QString getColorQuantity();
     QString getVectorOrigin();
+    QString getSpriteScale();
     ~Preferences();
 
 private:

--- a/source/preferences.ui
+++ b/source/preferences.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="Sprites">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="colorTab">
       <attribute name="title">
@@ -629,6 +629,42 @@
           </widget>
          </item>
          <item>
+          <widget class="QLabel" name="label_15">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Sprite Scale</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="scaleNormalized">
+           <property name="text">
+            <string>Normalized</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">spriteScaleGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="scaleProportional">
+           <property name="text">
+            <string>Proportional</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">spriteScaleGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
           <spacer name="verticalSpacer_5">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -989,8 +1025,9 @@
   </connection>
  </connections>
  <buttongroups>
+  <buttongroup name="vectorOriginGroup"/>
   <buttongroup name="coloredQuantityGroup"/>
   <buttongroup name="colorScaleGroup"/>
-  <buttongroup name="vectorOriginGroup"/>
+  <buttongroup name="spriteScaleGroup"/>
  </buttongroups>
 </ui>

--- a/source/window.cpp
+++ b/source/window.cpp
@@ -262,6 +262,7 @@ void Window::updatePrefs() {
     }
     viewport->setColoredQuantity(prefs->getColorQuantity());
     viewport->setColorScale(prefs->getColorScale());
+    viewport->setSpriteScale(prefs->getSpriteScale());
 }
 
 void Window::openSettings()


### PR DESCRIPTION
Option to scale all arrows/cones according to the largest magnitude.

Could use better naming for the options :p
